### PR TITLE
Improve portfolio layout with CSS Grid

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -30,8 +30,15 @@ section {
     padding: 20px;
 }
 
+.portfolio-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    column-gap: 20px;
+    row-gap: 20px;
+}
+
 .portfolio-section {
-    margin-bottom: 30px;
+    margin: 0;
 }
 
 .heritage-gallery img {

--- a/index.html
+++ b/index.html
@@ -26,19 +26,20 @@
 
     <section id="portfolio">
         <h2>Portfolio</h2>
-        <div class="portfolio-section">
+        <div class="portfolio-grid">
+            <div class="portfolio-section">
             <h3>Knits</h3>
             <p>Add photos or descriptions of your knitting projects.</p>
-        </div>
-        <div class="portfolio-section">
+            </div>
+            <div class="portfolio-section">
             <h3>Prints</h3>
             <p>Add photos or descriptions of your print works.</p>
-        </div>
-        <div class="portfolio-section">
+            </div>
+            <div class="portfolio-section">
             <h3>Weave</h3>
             <p>Add photos or descriptions of your weaving projects.</p>
-        </div>
-        <div class="portfolio-section">
+            </div>
+            <div class="portfolio-section">
             <h3>Garment</h3>
             <p>
                 Add photos or descriptions of your garment projects. You can showcase your two garments from the "Heritage Threads" event by placing images named <code>heritage1.jpg</code> and <code>heritage2.jpg</code> in the <code>images</code> folder. They will automatically appear below if added.
@@ -47,10 +48,11 @@
                 <img src="images/heritage1.jpg" alt="Heritage Threads garment 1">
                 <img src="images/heritage2.jpg" alt="Heritage Threads garment 2">
             </div>
-        </div>
-        <div class="portfolio-section">
+            </div>
+            <div class="portfolio-section">
             <h3>Embroidery</h3>
             <p>Add photos or descriptions of your embroidery.</p>
+            </div>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- set up a `.portfolio-grid` CSS Grid container
- remove bottom margins from `.portfolio-section`
- group portfolio items in `index.html` inside the new grid container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868878f3ffc8329b74b1ef4ac711648