### PR TITLE
Implement sticky header and scroll spy

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -9,6 +9,9 @@ header {
     background-color: #f0f0f0;
     padding: 20px;
     text-align: center;
+    position: sticky;
+    top: 0;
+    z-index: 1000;
 }
 
 nav ul {
@@ -24,6 +27,11 @@ nav li {
 nav a {
     text-decoration: none;
     color: #333;
+}
+
+nav a.active {
+    font-weight: bold;
+    color: #000;
 }
 
 section {

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -7,4 +7,24 @@ document.addEventListener('DOMContentLoaded', function () {
         statusDiv.textContent = 'Thank you for reaching out. I will get back to you soon!';
         form.reset();
     });
+
+    const sections = document.querySelectorAll('section');
+    const navLinks = document.querySelectorAll('nav a');
+    const header = document.querySelector('header');
+
+    function setActiveLink() {
+        let currentSection = sections[0];
+        sections.forEach((section) => {
+            if (window.scrollY >= section.offsetTop - header.offsetHeight) {
+                currentSection = section;
+            }
+        });
+
+        navLinks.forEach((link) => {
+            link.classList.toggle('active', link.getAttribute('href') === `#${currentSection.id}`);
+        });
+    }
+
+    window.addEventListener('scroll', setActiveLink);
+    setActiveLink();
 });


### PR DESCRIPTION
## Summary
- keep the header visible by making it sticky
- highlight the active navigation link while scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68688791fdcc8329add729e9f9a4b482