### PR TITLE
Add Google Fonts for modern typography

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,8 +1,12 @@
 body {
-    font-family: Arial, Helvetica, sans-serif;
+    font-family: 'Roboto', Arial, Helvetica, sans-serif;
     margin: 0;
     padding: 0;
     line-height: 1.6;
+}
+
+h1, h2, h3 {
+    font-family: 'Playfair Display', 'Times New Roman', serif;
 }
 
 header {

--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Art Portfolio</title>
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- include Playfair Display & Roboto from Google Fonts
- apply Roboto for body text and Playfair Display for headings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868879705648329a881bf0eb62551e2