### PR TITLE
Enable draggable image panning

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -34,9 +34,23 @@ section {
     margin-bottom: 30px;
 }
 
-.heritage-gallery img {
-    max-width: 200px;
+.pan-wrapper {
+    overflow: hidden;
+    display: inline-block;
+    position: relative;
+    cursor: grab;
+    width: 200px;
     margin-right: 10px;
+}
+
+.pan-wrapper.dragging {
+    cursor: grabbing;
+}
+
+.pan-wrapper img {
+    user-select: none;
+    pointer-events: none;
+    display: block;
 }
 
 footer {

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -7,4 +7,44 @@ document.addEventListener('DOMContentLoaded', function () {
         statusDiv.textContent = 'Thank you for reaching out. I will get back to you soon!';
         form.reset();
     });
+
+    const wrappers = document.querySelectorAll('.pan-wrapper');
+    wrappers.forEach(wrapper => {
+        const img = wrapper.querySelector('img');
+        let isDragging = false;
+        let startX = 0;
+        let startY = 0;
+        let imgX = 0;
+        let imgY = 0;
+
+        wrapper.addEventListener('mousedown', e => {
+            e.preventDefault();
+            isDragging = true;
+            startX = e.clientX;
+            startY = e.clientY;
+            wrapper.classList.add('dragging');
+        });
+
+        document.addEventListener('mousemove', e => {
+            if (!isDragging) return;
+            const dx = e.clientX - startX;
+            const dy = e.clientY - startY;
+            img.style.transform = `translate(${imgX + dx}px, ${imgY + dy}px)`;
+        });
+
+        const endDrag = () => {
+            if (!isDragging) return;
+            isDragging = false;
+            const match = /translate\((-?\d+(?:\.\d+)?)px,\s*(-?\d+(?:\.\d+)?)px\)/.exec(img.style.transform);
+            if (match) {
+                imgX = parseFloat(match[1]);
+                imgY = parseFloat(match[2]);
+            }
+            wrapper.classList.remove('dragging');
+        };
+
+        document.addEventListener('mouseup', endDrag);
+        wrapper.addEventListener('mouseleave', endDrag);
+        wrapper.addEventListener('dragstart', e => e.preventDefault());
+    });
 });

--- a/index.html
+++ b/index.html
@@ -44,8 +44,12 @@
                 Add photos or descriptions of your garment projects. You can showcase your two garments from the "Heritage Threads" event by placing images named <code>heritage1.jpg</code> and <code>heritage2.jpg</code> in the <code>images</code> folder. They will automatically appear below if added.
             </p>
             <div class="heritage-gallery">
-                <img src="images/heritage1.jpg" alt="Heritage Threads garment 1">
-                <img src="images/heritage2.jpg" alt="Heritage Threads garment 2">
+                <div class="pan-wrapper">
+                    <img src="images/heritage1.jpg" alt="Heritage Threads garment 1">
+                </div>
+                <div class="pan-wrapper">
+                    <img src="images/heritage2.jpg" alt="Heritage Threads garment 2">
+                </div>
             </div>
         </div>
         <div class="portfolio-section">


### PR DESCRIPTION
## Summary
- wrap heritage garment images in `.pan-wrapper` containers
- add CSS styles for draggable panning
- implement drag logic in `scripts.js`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6868879e6418832982e041d1e90dac15