### PR TITLE
Enable lightbox keyboard controls

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -44,3 +44,25 @@ footer {
     text-align: center;
     padding: 10px;
 }
+
+.lightbox-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.8);
+    display: none;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.lightbox-overlay.active {
+    display: flex;
+}
+
+.lightbox-overlay img {
+    max-width: 90%;
+    max-height: 90%;
+}

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -7,4 +7,46 @@ document.addEventListener('DOMContentLoaded', function () {
         statusDiv.textContent = 'Thank you for reaching out. I will get back to you soon!';
         form.reset();
     });
+
+    // Lightbox functionality
+    const galleryImages = document.querySelectorAll('.heritage-gallery img');
+    if (galleryImages.length) {
+        const lightbox = document.createElement('div');
+        lightbox.className = 'lightbox-overlay';
+        const lightboxImg = document.createElement('img');
+        lightbox.appendChild(lightboxImg);
+        document.body.appendChild(lightbox);
+
+        const srcList = Array.from(galleryImages).map(img => img.src);
+        let currentIndex = 0;
+
+        const keyHandler = function (e) {
+            if (!lightbox.classList.contains('active')) return;
+            if (e.key === 'ArrowRight') {
+                currentIndex = (currentIndex + 1) % srcList.length;
+                lightboxImg.src = srcList[currentIndex];
+            } else if (e.key === 'ArrowLeft') {
+                currentIndex = (currentIndex - 1 + srcList.length) % srcList.length;
+                lightboxImg.src = srcList[currentIndex];
+            } else if (e.key === 'Escape') {
+                closeLightbox();
+            }
+        };
+
+        const closeLightbox = function () {
+            lightbox.classList.remove('active');
+            document.removeEventListener('keydown', keyHandler);
+        };
+
+        galleryImages.forEach((img, index) => {
+            img.addEventListener('click', () => {
+                currentIndex = index;
+                lightboxImg.src = srcList[currentIndex];
+                lightbox.classList.add('active');
+                document.addEventListener('keydown', keyHandler);
+            });
+        });
+
+        lightbox.addEventListener('click', closeLightbox);
+    }
 });


### PR DESCRIPTION
## Summary
- add overlay styles for a simple lightbox
- implement lightbox open/close and image navigation with keyboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868879f2c2c83299f03812c0506fff7