### PR TITLE
Improve layout and navigation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,3 +1,10 @@
+:root {
+    --color-bg-light: #ffffff;
+    --color-bg-alt: #f7f7f7;
+    --color-primary: #0b3d91;
+    --color-accent: #eb5e28;
+}
+
 html {
     scroll-behavior: smooth;
 }
@@ -14,7 +21,7 @@ h1, h2, h3 {
 }
 
 header {
-    background-color: #f0f0f0;
+    background-color: var(--color-bg-alt);
     padding: 20px;
     text-align: center;
     position: sticky;
@@ -27,6 +34,14 @@ nav ul {
     padding: 0;
 }
 
+.nav-toggle {
+    display: none;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    margin-left: 10px;
+}
+
 nav li {
     display: inline-block;
     margin: 0 10px;
@@ -34,25 +49,27 @@ nav li {
 
 nav a {
     text-decoration: none;
-    color: #333;
+    color: var(--color-primary);
+    transition: color 0.2s;
 }
 
+nav a:hover,
 nav a.active {
+    color: var(--color-accent);
     font-weight: bold;
-    color: #000;
 }
 
 section {
     padding: 40px 20px;
-    margin: 40px 0;
+    margin: 60px 0;
 }
 
 section:nth-of-type(even) {
-    background-color: #f7f7f7;
+    background-color: var(--color-bg-alt);
 }
 
 section:nth-of-type(odd) {
-    background-color: #ffffff;
+    background-color: var(--color-bg-light);
 }
 
 .portfolio-grid {
@@ -64,6 +81,10 @@ section:nth-of-type(odd) {
 
 .portfolio-section {
     margin: 0;
+    background-color: var(--color-bg-light);
+    border-radius: 8px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    padding: 20px;
 }
 
 
@@ -72,6 +93,11 @@ section:nth-of-type(odd) {
     display: inline-block;
     margin-right: 10px;
     text-align: center;
+    transition: transform 0.2s;
+}
+
+.gallery-item:hover {
+    transform: scale(1.05);
 }
 
 .gallery-item img {
@@ -81,7 +107,7 @@ section:nth-of-type(odd) {
 
 .gallery-item a {
     text-decoration: none;
-    color: #333;
+    color: var(--color-primary);
 }
 
 .gallery-item h4 {
@@ -91,7 +117,7 @@ section:nth-of-type(odd) {
 
 
 footer {
-    background-color: #f0f0f0;
+    background-color: var(--color-bg-alt);
     text-align: center;
     padding: 10px;
 }
@@ -127,4 +153,19 @@ footer {
 
 .lightbox-overlay.show img {
     transform: translateY(0);
+}
+@media (max-width: 600px) {
+    nav ul {
+        display: none;
+    }
+    nav.open ul {
+        display: block;
+    }
+    nav li {
+        display: block;
+        margin: 10px 0;
+    }
+    .nav-toggle {
+        display: inline-block;
+    }
 }

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -34,6 +34,14 @@ document.addEventListener('DOMContentLoaded', function () {
     const sections = document.querySelectorAll('section');
     const navLinks = document.querySelectorAll('nav a');
     const header = document.querySelector('header');
+    const navToggle = document.getElementById('nav-toggle');
+    const nav = document.querySelector('header nav');
+
+    if (navToggle) {
+        navToggle.addEventListener('click', () => {
+            nav.classList.toggle('open');
+        });
+    }
 
     function setActiveLink() {
         let currentSection = sections[0];

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 <body>
     <header>
         <h1>My Art Portfolio</h1>
+        <button id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
         <nav>
             <ul>
                 <li><a href="#about">About Me</a></li>
@@ -51,13 +52,13 @@
             <div class="heritage-gallery">
                 <div class="gallery-item">
                     <a href="images/heritage1.jpg">
-                        <img src="images/heritage1.jpg" alt="Heritage Threads garment 1">
+                        <img loading="lazy" src="images/heritage1.jpg" alt="Heritage Threads garment 1">
                         <h4>Heritage Threads garment 1</h4>
                     </a>
                 </div>
                 <div class="gallery-item">
                     <a href="images/heritage2.jpg">
-                        <img src="images/heritage2.jpg" alt="Heritage Threads garment 2">
+                        <img loading="lazy" src="images/heritage2.jpg" alt="Heritage Threads garment 2">
                         <h4>Heritage Threads garment 2</h4>
                     </a>
                 </div>


### PR DESCRIPTION
## Summary
- add CSS variables for consistent color palette
- style navigation and portfolio grid with card layouts
- introduce mobile nav toggle
- hook up navigation button in JS
- lazy load garment images

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68688d2d76208329aadce3e92470e85d