### PR TITLE
Add responsive navigation toggle

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -50,6 +50,11 @@ nav ul {
     padding: 0;
 }
 
+/* toggle button hidden by default */
+.nav-toggle {
+    display: none;
+}
+
 nav li {
     display: inline-block;
     margin: 0 var(--spacing-unit);
@@ -62,6 +67,29 @@ nav a {
 
 nav a:hover {
     color: var(--accent-color);
+}
+
+/* show/hide nav on small screens */
+@media (max-width: 768px) {
+    nav {
+        display: none;
+    }
+    header.nav-open nav {
+        display: block;
+    }
+    nav ul {
+        display: flex;
+        flex-direction: column;
+        margin: 0;
+    }
+    nav li {
+        display: block;
+        margin: var(--spacing-unit) 0;
+    }
+    .nav-toggle {
+        display: inline-block;
+        margin-top: var(--spacing-unit);
+    }
 }
 
 h1, h2, h3 {

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -34,6 +34,13 @@ document.addEventListener('DOMContentLoaded', function () {
     const sections = document.querySelectorAll('section');
     const navLinks = document.querySelectorAll('nav a');
     const header = document.querySelector('header');
+    const navToggle = document.querySelector('.nav-toggle');
+
+    if (navToggle) {
+        navToggle.addEventListener('click', () => {
+            header.classList.toggle('nav-open');
+        });
+    }
 
     function setActiveLink() {
         let currentSection = sections[0];

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 <body>
     <header>
         <h1>My Art Portfolio</h1>
+        <button class="nav-toggle" aria-label="Toggle navigation">Menu</button>
         <nav>
             <ul>
                 <li><a href="#about">About Me</a></li>


### PR DESCRIPTION
## Summary
- add toggle button to header
- style nav toggle and mobile menu
- enable nav opening on small screens via JS

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6868c4c702848329a955488767163780