### PR TITLE
Implement container layout and show more feature

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -109,6 +109,15 @@ section:nth-of-type(odd) {
     row-gap: var(--spacing-md);
 }
 
+.container {
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.more-items {
+    display: none;
+}
+
 .portfolio-section {
     margin: 0;
 }

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -50,4 +50,13 @@ document.addEventListener('DOMContentLoaded', function () {
 
     window.addEventListener('scroll', setActiveLink);
     setActiveLink();
+
+    const moreItems = document.querySelector('#portfolio .more-items');
+    const showMoreBtn = document.querySelector('#portfolio .show-more');
+    if (moreItems && showMoreBtn) {
+        showMoreBtn.addEventListener('click', () => {
+            moreItems.style.display = 'contents';
+            showMoreBtn.style.display = 'none';
+        });
+    }
 });

--- a/index.html
+++ b/index.html
@@ -23,66 +23,76 @@
         </nav>
     </header>
 
-    <section id="about">
-        <h2>About Me</h2>
-        <p>Write a short bio here. Mention your artistic background, your influences, and what you hope to achieve through your art.</p>
-    </section>
+    <div class="container">
+        <section id="about">
+            <h2>About Me</h2>
+            <p>Write a short bio here. Mention your artistic background, your influences, and what you hope to achieve through your art.</p>
+        </section>
+    </div>
 
-    <section id="portfolio">
-        <h2>Portfolio</h2>
-        <div class="portfolio-grid">
-            <div class="portfolio-section">
-            <h3>Knits</h3>
-            <p>Add photos or descriptions of your knitting projects.</p>
-            </div>
-            <div class="portfolio-section">
-            <h3>Prints</h3>
-            <p>Add photos or descriptions of your print works.</p>
-            </div>
-            <div class="portfolio-section">
-            <h3>Weave</h3>
-            <p>Add photos or descriptions of your weaving projects.</p>
-            </div>
-            <div class="portfolio-section">
-            <h3>Garment</h3>
-            <p>
-                Add photos or descriptions of your garment projects. You can showcase your two garments from the "Heritage Threads" event by placing images named <code>heritage1.jpg</code> and <code>heritage2.jpg</code> in the <code>images</code> folder. They will automatically appear below if added.
-            </p>
-            <div class="heritage-gallery">
-
-                <div class="card">
-                    <img src="images/heritage1.jpg" alt="Heritage Threads garment 1">
+    <div class="container">
+        <section id="portfolio">
+            <h2>Portfolio</h2>
+            <div class="portfolio-grid">
+                <div class="portfolio-section">
+                    <h3>Knits</h3>
+                    <p>Add photos or descriptions of your knitting projects.</p>
                 </div>
-                <div class="card">
-                    <img src="images/heritage2.jpg" alt="Heritage Threads garment 2">
+                <div class="portfolio-section">
+                    <h3>Prints</h3>
+                    <p>Add photos or descriptions of your print works.</p>
+                </div>
+                <div class="more-items">
+                    <div class="portfolio-section">
+                        <h3>Weave</h3>
+                        <p>Add photos or descriptions of your weaving projects.</p>
+                    </div>
+                    <div class="portfolio-section">
+                        <h3>Garment</h3>
+                        <p>
+                            Add photos or descriptions of your garment projects. You can showcase your two garments from the "Heritage Threads" event by placing images named <code>heritage1.jpg</code> and <code>heritage2.jpg</code> in the <code>images</code> folder. They will automatically appear below if added.
+                        </p>
+                        <div class="heritage-gallery">
+                            <div class="card">
+                                <img src="images/heritage1.jpg" alt="Heritage Threads garment 1">
+                            </div>
+                            <div class="card">
+                                <img src="images/heritage2.jpg" alt="Heritage Threads garment 2">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="portfolio-section">
+                        <h3>Embroidery</h3>
+                        <p>Add photos or descriptions of your embroidery.</p>
+                    </div>
                 </div>
             </div>
-            </div>
-            <div class="portfolio-section">
-            <h3>Embroidery</h3>
-            <p>Add photos or descriptions of your embroidery.</p>
-            </div>
-        </div>
-    </section>
+            <button class="show-more" type="button">Show More</button>
+        </section>
+    </div>
 
-    <section id="cv">
-        <h2>CV</h2>
-        <p>Include your CV or a link to a downloadable PDF version here.</p>
-    </section>
+    <div class="container">
+        <section id="cv">
+            <h2>CV</h2>
+            <p>Include your CV or a link to a downloadable PDF version here.</p>
+        </section>
+    </div>
 
-    <section id="contact">
-        <h2>Contact Me</h2>
-        <form id="contact-form">
-            <label for="name">Name:</label>
-            <input type="text" id="name" name="name" required>
-            <label for="email">Email:</label>
-            <input type="email" id="email" name="email" required>
-            <label for="message">Message:</label>
-            <textarea id="message" name="message" required></textarea>
-            <button type="submit">Send</button>
-        </form>
-        <div id="form-status"></div>
-    </section>
+    <div class="container">
+        <section id="contact">
+            <h2>Contact Me</h2>
+            <form id="contact-form">
+                <label for="name">Name:</label>
+                <input type="text" id="name" name="name" required>
+                <label for="email">Email:</label>
+                <input type="email" id="email" name="email" required>
+                <label for="message">Message:</label>
+                <textarea id="message" name="message" required></textarea>
+                <button type="submit">Send</button>
+            </form>
+            <div id="form-status"></div>
+        </section>
+    </div>
 
     <footer>
         <p>&copy; 2023 Your Name. All Rights Reserved.</p>


### PR DESCRIPTION
## Summary
- wrap each section in a `.container` div
- reorganize portfolio items with highlighted works shown first
- hide additional portfolio items in a `.more-items` block and reveal with a button
- add `.container` and `.more-items` CSS rules
- implement JS to show more portfolio items

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868c4c768648329b7eeb895713ae28a