### PR TITLE
Add dynamic gallery loading and clean theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@ left sidebar for navigation. The menu links are:
 
 ## Adding Images
 
-Place any artwork images inside the `images` directory. Two placeholder files are referenced for the "Heritage Threads" garments:
-
-- `images/heritage1.jpg`
-- `images/heritage2.jpg`
-
-Add your actual image files with those names and they will appear automatically in the Garment section.
+Store your artwork in the `images` directory and list each file in the
+corresponding gallery page. Every gallery page defines a small JavaScript array
+named `artworks` describing the images for that section. Update the array with
+new objects containing the file path, title, year, medium and dimensions. The
+page will automatically render all items using `assets/js/gallery.js`.
 
 ## Running Locally
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6,11 +6,15 @@
 }
 
 body {
-  font-family: 'Outfit', sans-serif;
+  font-family: Arial, sans-serif;
   line-height: 1.6;
-  background-color: #f9f9f9;
-  color: #333;
+  background-color: #fafafa;
+  color: #000;
   margin-left: 240px;
+}
+
+h1, h2, h3 {
+  font-family: Georgia, serif;
 }
 
 .sidebar {
@@ -142,6 +146,24 @@ footer {
 .gallery-grid figcaption {
   margin-top: 0.5rem;
   font-size: 0.9rem;
+}
+
+/* Thin custom scrollbar */
+body::-webkit-scrollbar {
+  width: 6px;
+}
+
+body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+body::-webkit-scrollbar-thumb {
+  background: #ccc;
+  border-radius: 3px;
+}
+
+body::-webkit-scrollbar-thumb:hover {
+  background: #999;
 }
 
 @media (max-width: 768px) {

--- a/assets/js/gallery.js
+++ b/assets/js/gallery.js
@@ -1,0 +1,24 @@
+function renderGallery(images) {
+  const container = document.getElementById('gallery-container');
+  if (!container || !Array.isArray(images)) return;
+  images.forEach(item => {
+    const figure = document.createElement('figure');
+
+    const img = document.createElement('img');
+    img.src = item.src;
+    img.alt = item.title;
+    figure.appendChild(img);
+
+    const caption = document.createElement('figcaption');
+    caption.innerHTML = `${item.title} – ${item.year}<br>${item.medium}, ${item.dimensions}`;
+    figure.appendChild(caption);
+
+    container.appendChild(figure);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (typeof artworks !== 'undefined') {
+    renderGallery(artworks);
+  }
+});

--- a/gallery/embroidery.html
+++ b/gallery/embroidery.html
@@ -28,14 +28,21 @@
 
   <main>
     <h1>Embroidery</h1>
-    <div class="gallery-grid">
-      <figure>
-        <img src="../images/embroidery1.jpg" alt="Embroidery piece 1" />
-        <figcaption>Title – Year<br />Medium, Dimensions</figcaption>
-      </figure>
-      <!-- Duplicate the figure block above to add more works -->
-    </div>
+    <div class="gallery-grid" id="gallery-container"></div>
   </main>
+
+  <script>
+    const artworks = [
+      {
+        src: "../images/embroidery1.jpg",
+        title: "Title",
+        year: "Year",
+        medium: "Medium",
+        dimensions: "Dimensions"
+      }
+    ];
+  </script>
+  <script src="../assets/js/gallery.js"></script>
 
   <script src="../assets/js/scripts.js"></script>
 </body>

--- a/gallery/garment.html
+++ b/gallery/garment.html
@@ -28,18 +28,28 @@
 
   <main>
     <h1>Garment</h1>
-    <div class="gallery-grid">
-      <figure>
-        <img src="../images/heritage1.jpg" alt="Heritage Threads 1" />
-        <figcaption>Heritage Threads 1 – Year<br />Medium, Dimensions</figcaption>
-      </figure>
-      <figure>
-        <img src="../images/heritage2.jpg" alt="Heritage Threads 2" />
-        <figcaption>Heritage Threads 2 – Year<br />Medium, Dimensions</figcaption>
-      </figure>
-      <!-- Duplicate the figure block above to add more works -->
-    </div>
+    <div class="gallery-grid" id="gallery-container"></div>
   </main>
+
+  <script>
+    const artworks = [
+      {
+        src: "../images/heritage1.jpg",
+        title: "Heritage Threads 1",
+        year: "Year",
+        medium: "Medium",
+        dimensions: "Dimensions"
+      },
+      {
+        src: "../images/heritage2.jpg",
+        title: "Heritage Threads 2",
+        year: "Year",
+        medium: "Medium",
+        dimensions: "Dimensions"
+      }
+    ];
+  </script>
+  <script src="../assets/js/gallery.js"></script>
 
   <script src="../assets/js/scripts.js"></script>
 </body>

--- a/gallery/knit.html
+++ b/gallery/knit.html
@@ -28,14 +28,21 @@
 
   <main>
     <h1>Knit</h1>
-    <div class="gallery-grid">
-      <figure>
-        <img src="../images/knit1.jpg" alt="Knit piece 1" />
-        <figcaption>Title – Year<br />Medium, Dimensions</figcaption>
-      </figure>
-      <!-- Duplicate the figure block above to add more works -->
-    </div>
+    <div class="gallery-grid" id="gallery-container"></div>
   </main>
+
+  <script>
+    const artworks = [
+      {
+        src: "../images/knit1.jpg",
+        title: "Title",
+        year: "Year",
+        medium: "Medium",
+        dimensions: "Dimensions"
+      }
+    ];
+  </script>
+  <script src="../assets/js/gallery.js"></script>
 
   <script src="../assets/js/scripts.js"></script>
 </body>

--- a/gallery/print.html
+++ b/gallery/print.html
@@ -28,14 +28,21 @@
 
   <main>
     <h1>Print</h1>
-    <div class="gallery-grid">
-      <figure>
-        <img src="../images/print1.jpg" alt="Print piece 1" />
-        <figcaption>Title – Year<br />Medium, Dimensions</figcaption>
-      </figure>
-      <!-- Duplicate the figure block above to add more works -->
-    </div>
+    <div class="gallery-grid" id="gallery-container"></div>
   </main>
+
+  <script>
+    const artworks = [
+      {
+        src: "../images/print1.jpg",
+        title: "Title",
+        year: "Year",
+        medium: "Medium",
+        dimensions: "Dimensions"
+      }
+    ];
+  </script>
+  <script src="../assets/js/gallery.js"></script>
 
   <script src="../assets/js/scripts.js"></script>
 </body>

--- a/gallery/weave.html
+++ b/gallery/weave.html
@@ -28,14 +28,21 @@
 
   <main>
     <h1>Weave</h1>
-    <div class="gallery-grid">
-      <figure>
-        <img src="../images/weave1.jpg" alt="Weave piece 1" />
-        <figcaption>Title – Year<br />Medium, Dimensions</figcaption>
-      </figure>
-      <!-- Duplicate the figure block above to add more works -->
-    </div>
+    <div class="gallery-grid" id="gallery-container"></div>
   </main>
+
+  <script>
+    const artworks = [
+      {
+        src: "../images/weave1.jpg",
+        title: "Title",
+        year: "Year",
+        medium: "Medium",
+        dimensions: "Dimensions"
+      }
+    ];
+  </script>
+  <script src="../assets/js/gallery.js"></script>
 
   <script src="../assets/js/scripts.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- use serif headings and lighter background
- add thin custom scrollbar styling
- create `gallery.js` to populate galleries from JS arrays
- convert all gallery pages to use dynamic `artworks` arrays
- update README instructions about adding images

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868d04943748329afe0bb891f212220